### PR TITLE
configure for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,4 +37,10 @@
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
 
+	"overrideCommand": true,
+
+	"mounts": [
+		"source=./,target=/home/developer/dev,type=bind,consistency=cached"
+	]
+
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ COPY ble.py $HOME/ble.py
 COPY tcp.py $HOME/tcp.py
 COPY dgatt.py $HOME/dgatt.py
 COPY entrypoint.sh /entrypoint.sh
-COPY cabot-device-check/check_device_status.sh $HOME/check_device_status.sh
+COPY cabot-device-check/check_device_status.sh $HOME/cabot-device-check/check_device_status.sh
 COPY cabot-device-check/locale $HOME/locale
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/cabot_app.py
+++ b/cabot_app.py
@@ -190,9 +190,9 @@ class CaBotManager(BatteryDriverDelegate):
 
     def _check_device_status(self):
         if self._cabot_system_status.is_active():
-            result = self._runprocess(["sudo", "-E", "./check_device_status.sh", "-j", "-s"])
+            result = self._runprocess(["sudo", "-E", "./cabot-device-check/check_device_status.sh", "-j", "-s"])
         else:
-            result = self._runprocess(["sudo", "-E", "./check_device_status.sh", "-j"])
+            result = self._runprocess(["sudo", "-E", "./cabot-device-check/check_device_status.sh", "-j"])
         if result and result.returncode == 0:
             self._device_status.ok()
         else:


### PR DESCRIPTION
- configure devcontainer.json so that developers can test on the container
  - do not run cabot_app.py at the container start
  - mount the code at `~/dev`
  - change the `check_device_status.sh` location to use the same path both in development and production 


- Known issues
  - the script `cabot_app.py` cannot be stopped by Ctrl+C (or docker-compose down)