### PR TITLE
Add config to power off remote hosts by power off button

### DIFF
--- a/.env
+++ b/.env
@@ -27,6 +27,9 @@
 # specify jetson mate config. expects a config which is provided for cabot
 #CABOT_JETSON_CONFIG="D:192.168.1.51:rs1 D:192.168.1.52:rs2 D:192.168.1.53:rs3"
 
+# specify remote hosts in the order to power off by the power off button
+#CABOT_REMOTE_POWEROFF_CONFIG
+
 ## optional variables but check speed will up if provided
 # network interface name which the lidar connected to
 #LIDAR_IF=enp8s0

--- a/.env
+++ b/.env
@@ -24,8 +24,11 @@
 #CABOT_CAMERA_NAME_2
 #CABOT_CAMERA_NAME_3
 
+# User name to login jetson (default=cabot)
+#CABOT_JETSON_USER=cabot
 # specify jetson mate config. expects a config which is provided for cabot
-#CABOT_JETSON_CONFIG="D:192.168.1.51:rs1 D:192.168.1.52:rs2 D:192.168.1.53:rs3"
+# jetson hosts will be automaticallly shutdown in the written order
+#CABOT_JETSON_CONFIG="D:192.168.1.52:rs3 D:192.168.1.51:rs2 D:192.168.1.50:rs1"
 
 # specify remote hosts in the order to power off by the power off button
 #CABOT_REMOTE_POWEROFF_CONFIG

--- a/.env
+++ b/.env
@@ -24,14 +24,13 @@
 #CABOT_CAMERA_NAME_2
 #CABOT_CAMERA_NAME_3
 
-# User name to login jetson (default=cabot)
+# user name to login jetson (default=cabot)
 #CABOT_JETSON_USER=cabot
+# ssh id file to connect jetson
+#CABOT_ID_FILE=id_ed25519_cabot
 # specify jetson mate config. expects a config which is provided for cabot
 # jetson hosts will be automaticallly shutdown in the written order
 #CABOT_JETSON_CONFIG="D:192.168.1.52:rs3 D:192.168.1.51:rs2 D:192.168.1.50:rs1"
-
-# specify remote hosts in the order to power off by the power off button
-#CABOT_REMOTE_POWEROFF_CONFIG
 
 ## optional variables but check speed will up if provided
 # network interface name which the lidar connected to
@@ -41,8 +40,3 @@
 
 # specify Arduino or ESP32
 #MICRO_CONTROLLER=Arduino
-
-
-# optional variables for jetson connection
-#CABOT_USER_NAME=cabot
-#CABOT_ID_FILE=id_ed25519_cabot

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ CABOT_CAMERA_NAME_3
 CABOT_JETSON_CONFIG="D:192.168.1.51:rs1 D:192.168.1.52:rs2 D:192.168.1.53:rs3"
 ```
 
+## variable to power off remote hosts by the power off button
+```
+CABOT_REMOTE_POWEROFF_CONFIG
+# specify remote hosts in the order to power off by the power off button
+# write in the format <user name>@<host name>,
+# and separate config for multiple hosts by space
+# ex) "cabot@192.158.1.52 cabot@192.158.1.51 cabot@192.158.1.50"
+```
+
+Please modify your "~/.ssh/config", and make make sure you can connect from docker contaier to remote hosts by ssh without password.
+An example setting is below.
+```
+Host 192.168.1.*
+    IdentityFile ~/.ssh/id_ed25519_cabot
+```
+
+In remote hosts, please use "visudo" command to modify "/etc/sudoer" and add the following line.
+```
+cabot   ALL=NOPASSWD: /sbin/poweroff
+```
+
 ##
 
 

--- a/README.md
+++ b/README.md
@@ -51,26 +51,16 @@ CABOT_CAMERA_NAME_3
 ```
 - NUC + Jetson (Realsense x 3)
 ```
-CABOT_JETSON_CONFIG="D:192.168.1.51:rs1 D:192.168.1.52:rs2 D:192.168.1.53:rs3"
+# User name to login jetson (default=cabot)
+CABOT_JETSON_USER=cabot
+# specify jetson mate config. expects a config which is provided for cabot
+# jetson hosts will be automaticallly shutdown in the written order
+CABOT_JETSON_CONFIG="D:192.168.1.52:rs3 D:192.168.1.51:rs2 D:192.168.1.50:rs1"
+# ssh id file to log in jetson
+CABOT_ID_FILE=id_ed25519_cabot
 ```
 
-## variable to power off remote hosts by the power off button
-```
-CABOT_REMOTE_POWEROFF_CONFIG
-# specify remote hosts in the order to power off by the power off button
-# write in the format <user name>@<host name>,
-# and separate config for multiple hosts by space
-# ex) "cabot@192.158.1.52 cabot@192.158.1.51 cabot@192.158.1.50"
-```
-
-Please modify your "~/.ssh/config", and make make sure you can connect from docker contaier to remote hosts by ssh without password.
-An example setting is below.
-```
-Host 192.168.1.*
-    IdentityFile ~/.ssh/id_ed25519_cabot
-```
-
-In remote hosts, please use "visudo" command to modify "/etc/sudoer" and add the following line.
+On Jetson hosts, please use "visudo" command to modify "/etc/sudoer" and add the following line to shutdown Jetson automatically.
 ```
 cabot   ALL=NOPASSWD: /sbin/poweroff
 ```

--- a/cabot_app.py
+++ b/cabot_app.py
@@ -141,7 +141,7 @@ class SystemStatus:
         self.diagnostics = []
 
 class CaBotManager(BatteryDriverDelegate):
-    def __init__(self, remote_poweroff_commands=None):
+    def __init__(self, jetson_poweroff_commands=None):
         self._device_status = DeviceStatus()
         self._cabot_system_status = SystemStatus()
         self._battery_status = None
@@ -150,7 +150,7 @@ class CaBotManager(BatteryDriverDelegate):
         self.stop_run = None
         self.check_interval = 1
         self.run_count = 0
-        self._remote_poweroff_commands = remote_poweroff_commands
+        self._jetson_poweroff_commands = jetson_poweroff_commands
 
     def run(self, start=False):
         self.start_flag=start
@@ -242,8 +242,9 @@ class CaBotManager(BatteryDriverDelegate):
         self._call(["sudo", "systemctl", "reboot"], lock=self.systemctl_lock)
 
     def poweroff(self):
-        if self._remote_poweroff_commands is not None:
-            for command in self._remote_poweroff_commands:
+        if self._jetson_poweroff_commands is not None:
+            for command in self._jetson_poweroff_commands:
+                common.logger.info("send shutdown request to jetson: %s", str(command))
                 self._call(command, lock=self.systemctl_lock)
 
         self._call(["sudo", "systemctl", "poweroff"], lock=self.systemctl_lock)
@@ -293,19 +294,38 @@ def main():
     baud = int(os.environ['CABOT_ACE_BATTERY_BAUD']) if 'CABOT_ACE_BATTERY_BAUD' in os.environ else None
 
     cabot_manager = CaBotManager()
-    remote_poweroff_commands = None
-    remote_poweroff_config = os.environ['CABOT_REMOTE_POWEROFF_CONFIG'] if 'CABOT_REMOTE_POWEROFF_CONFIG' in os.environ else None
-    if remote_poweroff_config is not None:
-        remote_poweroff_commands = []
-        items = remote_poweroff_config.split()
-        for item in items:
-            if item.find('@')==-1:
-                common.logger.error("Invalid value of CABOT_REMOTE_POWEROFF_CONFIG is found '{}'".format(item))
-                common.logger.error("Please separate user name and host name by the character @")
-                sys.exit()
-            remote_poweroff_commands.append(["ssh", item, "sudo poweroff"])
+    jetson_poweroff_commands = None
+    jetson_user = os.environ['CABOT_JETSON_USER'] if 'CABOT_JETSON_USER' in os.environ else "cabot"
+    jetson_config = os.environ['CABOT_JETSON_CONFIG'] if 'CABOT_JETSON_CONFIG' in os.environ else None
+    if jetson_config is not None:
+        id_file = os.environ['CABOT_ID_FILE'] if 'CABOT_ID_FILE' in os.environ else ""
+        id_dir = os.environ['CABOT_ID_DIR'] if 'CABOT_ID_DIR' in os.environ else ""
+        id_file_path = os.path.join(id_dir, id_file)
+        if not os.path.exists(id_file_path):
+            common.logger.error("ssh id file does not exist '{}'".format(id_file_path))
+            sys.exit()
 
-    cabot_manager = CaBotManager(remote_poweroff_commands=remote_poweroff_commands)
+        jetson_poweroff_commands = []
+        items = jetson_config.split()
+        for item in items:
+            split_item = item.split(':')
+            if len(split_item)!=3:
+                common.logger.error("Invalid value of CABOT_JETSON_CONFIG is found '{}'".format(item))
+                sys.exit()
+
+            result = subprocess.call(["ssh", "-i", id_file_path, jetson_user + "@" + split_item[1], "exit"])
+            if result != 0:
+                common.logger.error("Cannot connect Jetson host, please check ssh config. user:{}, host:{}, ssh key file:{}".format(jetson_user, split_item[1], id_file_path))
+                sys.exit()
+
+            result = subprocess.call(["ssh", "-i", id_file_path, jetson_user + "@" + split_item[1], "sudo poweroff -w"])
+            if result != 0:
+                common.logger.error("Cannot call poweroff on Jetson host, please check sudoer config. user:{}, host:{}".format(jetson_user, split_item[1], id_file_path))
+                sys.exit()
+
+            jetson_poweroff_commands.append(["ssh", "-i", id_file_path, jetson_user + "@" + split_item[1], "sudo poweroff"])
+
+    cabot_manager = CaBotManager(jetson_poweroff_commands=jetson_poweroff_commands)
     cabot_manager.run(start=start_at_launch)
 
     driver = None

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,8 +37,8 @@ services:
       - CABOT_CAMERA_NAME_1
       - CABOT_CAMERA_NAME_2
       - CABOT_CAMERA_NAME_3
+      - CABOT_JETSON_USER
       - CABOT_JETSON_CONFIG
-      - CABOT_REMOTE_POWEROFF_CONFIG
       - CABOT_USER_NAME
       - CABOT_ID_DIR=/home/developer/.ssh
       - CABOT_ID_FILE

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,6 @@ services:
       - CABOT_CAMERA_NAME_3
       - CABOT_JETSON_USER
       - CABOT_JETSON_CONFIG
-      - CABOT_USER_NAME
       - CABOT_ID_DIR=/home/developer/.ssh
       - CABOT_ID_FILE
       - LIDAR_IF

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
       - CABOT_CAMERA_NAME_2
       - CABOT_CAMERA_NAME_3
       - CABOT_JETSON_CONFIG
+      - CABOT_REMOTE_POWEROFF_CONFIG
       - CABOT_USER_NAME
       - CABOT_ID_DIR=/home/developer/.ssh
       - CABOT_ID_FILE


### PR DESCRIPTION
This pull request include changes to automatically power off remote hosts (Jetsons) by power off button.

DCO 1.1 Signed-off-by: Tatsuya Isihara <tisihara@jp.ibm.com>