### PR TITLE
bugfix: poweroff button of the ace model does not work

### DIFF
--- a/cabot_ace/cabot_ace_battery_driver.py
+++ b/cabot_ace/cabot_ace_battery_driver.py
@@ -4,6 +4,7 @@ import os
 import sys
 import inspect
 import logging
+import termios
 import traceback
 import threading
 import queue

--- a/cabot_app.py
+++ b/cabot_app.py
@@ -169,7 +169,7 @@ class CaBotManager(BatteryDriverDelegate):
         if status.shutdown or status.lowpower_shutdown:
             common.logger.info("shutdown requested")
             self.stop()
-            self.poweroff()
+            self.poweroffPC()
     # BatteryDriverDelegate end
 
     def add_log_request(self, request, callback):


### PR DESCRIPTION
fix a bug that poweroff button of the ace model does not work after commit https://github.com/CMU-cabot/cabot-ble-server/commit/9d96f8e0128bc245710958499d2fa895b86a4ed0